### PR TITLE
Fix intendation for parsers files

### DIFF
--- a/templates/td-agent-bit.conf.j2
+++ b/templates/td-agent-bit.conf.j2
@@ -28,9 +28,9 @@
     # ============
     # Specify an optional 'Parsers' configuration file
     Parsers_File parsers.conf
-    {% for parsers_file in fluentbit_service_custom_parsers_file %}
+{% for parsers_file in fluentbit_service_custom_parsers_file %}
     Parsers_File {{ parsers_file }}
-    {% endfor %}
+{% endfor %}
 
     Plugins_File plugins.conf
 


### PR DESCRIPTION
It is required to remove spaces before loop in the template or in other case 4 more spaces are added to each directive that produces intendation error in fluentbit