### PR TITLE
Add support for other apt-based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Role Variables
 | fluentbit_inputs  | false     | *[]*          | Array of inputs (in JSON format) to add in default conf file |
 | fluentbit_outputs  | false     | *[]*          | Array of ouputs (in JSON format) to add in default conf file |
 | fluentbit_additional_conf_files  | false     | *[]*          | Additional conf files to be installed, could be *Jinja* template |
+| fluentbit_apt_repo | false | *deb https://packages.fluentbit.io/ubuntu/bionic bionic main* | An apt source url to use |
 
 Dependencies
 ------------
@@ -46,6 +47,7 @@ passed in as parameters) is always nice for users too:
           fluentbit_service_log_level: info
           fluentbit_service_enable_metrics: true
           fluentbit_service_metrics_listen_port: 2020
+          fluentbit_apt_repo: 'deb https://packages.fluentbit.io/debian/buster buster main'
           fluentbit_inputs:
             - {"Name": "dummy", "Tag": "dummy.log"}
           fluentbit_outputs:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,5 @@ fluentbit_inputs: []
 fluentbit_outputs: []
 
 fluentbit_additional_conf_files: []
+
+fluentbit_apt_repo: 'deb https://packages.fluentbit.io/ubuntu/bionic bionic main'

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -7,7 +7,7 @@
 
 - name: Install Debian | Add td-agent-bit repository
   apt_repository:
-    repo: 'deb https://packages.fluentbit.io/ubuntu/bionic bionic main'
+    repo: '{{ fluentbit_apt_repo }}'
     state: present
     filename: td-agent-bit
     update_cache: true


### PR DESCRIPTION
Add support for apt-based distros other than Ubuntu by exposing an
optional role variable `fluentbit_apt_repo` that receives a full apt
sources configuration.

This enables users who want to run this role on targets running the
following OSs:

- Debian 10 (Buster)
- Debian 9 (Stretch)
- Debian 8 (Jessie)
- Raspbian 10 (Buster)
- Raspbian 9 (Stretch)
- Raspbian 8 (Jessie)

NOTE: it also opens up the ability to run this role on targets using
non-x86 architectures