### PR TITLE
Updating base url for centos7 repo

### DIFF
--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -3,7 +3,7 @@
 - name: Install Redhat | Add yum repository
   yum_repository:
     name: TD_Agent_Bit
-    baseurl: http://packages.fluentbit.io/centos/7
+    baseurl: http://packages.fluentbit.io/centos/7/$basearch/
     gpgcheck: true
     gpgkey: http://packages.fluentbit.io/fluentbit.key
     description: Fluent bit repo


### PR DESCRIPTION
Refers to changes in documentation: https://github.com/fluent/fluent-bit-docs/commit/19f8489c2f9bd3ed90664be440543d08cf005720