### PR TITLE
Allow proxy setup configuration for yum repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Role Variables
 | fluentbit_outputs  | false     | *[]*          | Array of ouputs (in JSON format) to add in default conf file |
 | fluentbit_additional_conf_files  | false     | *[]*          | Additional conf files to be installed, could be *Jinja* template |
 | fluentbit_apt_repo | false | *deb https://packages.fluentbit.io/ubuntu/bionic bionic main* | An apt source url to use |
+| fluentbit_yum_proxy | false | \_none\_ | URL to the proxy server that yum should use. |
 
 Dependencies
 ------------
@@ -55,6 +56,7 @@ passed in as parameters) is always nice for users too:
           fluentbit_additional_conf_files:
             - name: cpu.conf
               template: '{{ playbook_dir }}/templates/cpu.conf.j2'
+          fluentbit_yum_proxy: 'http://proxy:port'
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,4 @@ fluentbit_outputs: []
 fluentbit_additional_conf_files: []
 
 fluentbit_apt_repo: 'deb https://packages.fluentbit.io/ubuntu/bionic bionic main'
+fluentbit_yum_proxy: '_none_'

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -8,3 +8,4 @@
     gpgkey: http://packages.fluentbit.io/fluentbit.key
     description: Fluent bit repo
     enabled: true
+    proxy: '{{ fluentbit_yum_proxy }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
     state: present
     update_cache: true
   notify: Restart Fluentbit service
+  when: not ansible_check_mode
   tags: ['install']
 
 - import_tasks: configure.yml


### PR DESCRIPTION
@orachide This PR allows proxy setup configuration for the yum repository by exposing an optional role variable `fluentbit_yum_proxy`.